### PR TITLE
Use metadata tags to emulate instance groups

### DIFF
--- a/config.go
+++ b/config.go
@@ -21,10 +21,6 @@ func (g *InstanceGroup) validate() error {
 		errs = append(errs, fmt.Errorf("missing required plugin config: name"))
 	}
 
-	if g.Token == "" {
-		errs = append(errs, fmt.Errorf("missing required plugin config: token"))
-	}
-
 	if g.StrURL == "" {
 		errs = append(errs, fmt.Errorf("missing required plugin config: url"))
 	}
@@ -36,6 +32,10 @@ func (g *InstanceGroup) validate() error {
 
 	if g.Org == "" {
 		errs = append(errs, fmt.Errorf("missing required plugin config: org"))
+	}
+
+	if g.Token == "" {
+		errs = append(errs, fmt.Errorf("missing required plugin config: token"))
 	}
 
 	if g.VirtualDatacenter == "" {
@@ -54,6 +54,14 @@ func (g *InstanceGroup) validate() error {
 		errs = append(errs, fmt.Errorf("invalid ip_allocation_mode: %s", g.IPAllocationMode))
 	}
 
+	if g.InstanceGroupName == "" {
+		errs = append(errs, fmt.Errorf("missing required plugin config: instance_group_name"))
+	}
+
+	if g.VAppNamePrefix == "" {
+		errs = append(errs, fmt.Errorf("missing required plugin config: vapp_name_prefix"))
+	}
+
 	if g.Catalog == "" {
 		errs = append(errs, fmt.Errorf("missing required plugin config: catalog"))
 	}
@@ -62,13 +70,26 @@ func (g *InstanceGroup) validate() error {
 		errs = append(errs, fmt.Errorf("missing required plugin config: template"))
 	}
 
+	if g.StorageProfile == "" {
+		errs = append(errs, fmt.Errorf("missing required plugin config: storage_profile"))
+	}
+
 	if g.CPUCount == 0 {
 		errs = append(errs, fmt.Errorf("missing required plugin config: cpu_count"))
+	}
+
+	if g.CoresPerSocket == 0 {
+		errs = append(errs, fmt.Errorf("missing required plugin config: cores_per_socket"))
 	}
 
 	if g.MemoryMB == 0 {
 		errs = append(errs, fmt.Errorf("missing required plugin config: memory_mb"))
 	}
+
+	// Disk size is optional
+	// if g.DiskSizeGB == 0 {
+	// 	errs = append(errs, fmt.Errorf("missing required plugin config: disk_size_gb"))
+	// }
 
 	if g.settings.UseStaticCredentials {
 		if g.settings.Password == "" && g.settings.Key == nil {

--- a/go.mod
+++ b/go.mod
@@ -5,14 +5,14 @@ go 1.22.0
 require (
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/stretchr/testify v1.9.0
-	github.com/vmware/go-vcloud-director/v2 v2.25.0
-	gitlab.com/gitlab-org/fleeting/fleeting v0.0.0-20240723062336-da5f142b3c7d
+	github.com/vmware/go-vcloud-director/v2 v2.26.0
+	gitlab.com/gitlab-org/fleeting/fleeting v0.0.0-20240911165028-a0ce7d6c3260
 )
 
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
 	github.com/ChrisTrenkamp/goxpath v0.0.0-20210404020558-97928f7e12b6 // indirect
-	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195 // indirect
+	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de // indirect
 	github.com/bodgit/ntlmssp v0.0.0-20240506230425-31973bb52d9b // indirect
 	github.com/bodgit/windows v1.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -23,34 +23,35 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-plugin v1.6.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
-	github.com/hashicorp/go-version v1.2.0 // indirect
-	github.com/hashicorp/yamux v0.1.1 // indirect
+	github.com/hashicorp/go-version v1.7.0 // indirect
+	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
 	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect
 	github.com/jcmturner/gofork v1.7.6 // indirect
 	github.com/jcmturner/goidentity/v6 v6.0.1 // indirect
 	github.com/jcmturner/gokrb5/v8 v8.4.4 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
-	github.com/kr/pretty v0.2.1 // indirect
-	github.com/kr/text v0.1.0 // indirect
+	github.com/kr/pretty v0.3.1 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/masterzen/simplexml v0.0.0-20190410153822-31eea3082786 // indirect
 	github.com/masterzen/winrm v0.0.0-20240702205601-3fad6e106085 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/oklog/run v1.1.0 // indirect
-	github.com/peterhellberg/link v1.1.0 // indirect
+	github.com/peterhellberg/link v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/tidwall/transform v0.0.0-20201103190739-32f242e2dbde // indirect
-	golang.org/x/crypto v0.24.0 // indirect
-	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a // indirect
-	golang.org/x/mod v0.17.0 // indirect
-	golang.org/x/net v0.25.0 // indirect
-	golang.org/x/sys v0.21.0 // indirect
-	golang.org/x/text v0.16.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20240528184218-531527333157 // indirect
-	google.golang.org/grpc v1.64.0 // indirect
-	google.golang.org/protobuf v1.34.1 // indirect
+	golang.org/x/crypto v0.28.0 // indirect
+	golang.org/x/exp v0.0.0-20241004190924-225e2abe05e6 // indirect
+	golang.org/x/mod v0.21.0 // indirect
+	golang.org/x/net v0.30.0 // indirect
+	golang.org/x/sys v0.26.0 // indirect
+	golang.org/x/text v0.19.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20241007155032-5fefd90f89a9 // indirect
+	google.golang.org/grpc v1.67.1 // indirect
+	google.golang.org/protobuf v1.35.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/provider.go
+++ b/provider.go
@@ -8,11 +8,18 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	"gitlab.com/gitlab-org/fleeting/fleeting/provider"
 )
 
 var _ provider.InstanceGroup = (*InstanceGroup)(nil)
+
+const (
+	// vcd does not implement any kind of instance group
+	// so we use a metadata tag to identify the VMs of this fleeting instance group
+	instanceGroupMetadataKey = "fleeting-plugin-vcd"
+)
 
 type InstanceGroup struct {
 	Name string `json:"name"`
@@ -20,22 +27,23 @@ type InstanceGroup struct {
 	// Cloud Director connection config
 	StrURL            string `json:"url"`
 	Org               string `json:"org"`
+	Token             string `json:"token"`
 	VirtualDatacenter string `json:"virtual_datacenter"`
 	Network           string `json:"network"`
-	IPAllocationMode  string `json:"ip_allocation_mode"`
-	Token             string `json:"token"` // API token (vcd > 10.4 required)
+	IPAllocationMode  string `json:"ip_allocation_mode"`  // API token (vcd > 10.4 required)
+	InstanceGroupName string `json:"instance_group_name"` // Metadata tag to use for the VMs of this fleeting instance group
+	VAppNamePrefix    string `json:"vapp_name_prefix"`
 	Catalog           string `json:"catalog"`
 	Template          string `json:"template"`
-	VApp              string `json:"vapp"` // vApp to deploy workers on
-	VMNamePrefix      string `json:"vm_name_prefix"`
 	StorageProfile    string `json:"storage_profile"`
 	CPUCount          int    `json:"cpu_count"`
+	CoresPerSocket    int    `json:"cores_per_socket"`
 	MemoryMB          int64  `json:"memory_mb"`
+	DiskSizeGB        int    `json:"disk_size_gb"`
 
 	size int
 
 	parsedURL *url.URL
-	vAppHREF  string
 
 	log hclog.Logger
 
@@ -59,33 +67,21 @@ func (g *InstanceGroup) Init(ctx context.Context, logger hclog.Logger, settings 
 		return provider.ProviderInfo{}, fmt.Errorf("dynamic credentials are not supported yet")
 	}
 
-	vapp, err := g.getOrCreateVApp()
-	if err != nil {
-		return provider.ProviderInfo{}, fmt.Errorf("getting or creating vApp: %w", err)
-	}
-
-	g.vAppHREF = vapp.VApp.HREF // this speeds-up subsequent calls
-
 	return provider.ProviderInfo{
-		ID:        path.Join("vcd", g.Org, g.VirtualDatacenter, g.Network, g.VApp),
+		ID:        path.Join("vcd", g.Org, g.VirtualDatacenter, g.Network, g.VAppNamePrefix, g.InstanceGroupName),
 		MaxSize:   128, // max number of VMs in a vApp
 		Version:   Version.Version,
 		BuildInfo: Version.BuildInfo(),
 	}, nil
 }
 
-// TODO(juanfont): Right now, the Increase operation is extremely blocking, as it has to add a VM to the vApp one at a time.
-// This is because vcd does not support performing multiple operations in parallel inside the same vApp.
-// One possible solution is to create a new vApp for each VM, but this would require somehow keeping track of the created vApps.
 func (g *InstanceGroup) Increase(ctx context.Context, delta int) (int, error) {
+	fmt.Println("Increasing")
 	added := 0
 	for i := 1; i <= delta; i++ {
-		vm, err := g.addVMToVApp()
-		if err != nil {
-			continue
-		}
+		go g.createVM()
 		added++
-		g.log.Debug("added VM to vApp", "id", vm.VM.HREF, "name", vm.VM.Name)
+		g.log.Debug("added VM to vApp")
 	}
 
 	return added, nil
@@ -98,9 +94,8 @@ func (g *InstanceGroup) Decrease(ctx context.Context, instances []string) ([]str
 	}
 
 	deletedVMs := []string{}
-
 	for _, id := range instances {
-		if err := g.deleteVM(id); err != nil {
+		if err := g.deleteVApp(id); err != nil {
 			g.log.Error("deleting VM", "id", id, "error", err)
 		} else {
 			deletedVMs = append(deletedVMs, id)
@@ -112,41 +107,76 @@ func (g *InstanceGroup) Decrease(ctx context.Context, instances []string) ([]str
 
 // Update implements provider.InstanceGroup
 func (g *InstanceGroup) Update(ctx context.Context, update func(instance string, state provider.State)) error {
-	vapp, err := g.getVApp()
+	g.log.Debug("Updating instance group")
+	client, err := newClient(*g.parsedURL, g.Org, g.Token, false)
 	if err != nil {
-		return fmt.Errorf("getting vApp: %w", err)
+		return err
 	}
 
-	if vapp.VApp.Children == nil {
-		g.size = 0
-		return nil
+	vapps, err := g.getVappsInInstanceGroup()
+	if err != nil {
+		g.log.Error("error getting vapps in instance group", "error", err)
+		return fmt.Errorf("getting vapps in instance group: %w", err)
 	}
 
-	g.size = len(vapp.VApp.Children.VM)
+	g.log.Debug("found vapps", "number", len(vapps))
 
-	for _, vm := range vapp.VApp.Children.VM {
+	size := 0
+	for _, vapp := range vapps {
+		g.log.Debug("Checking status of vapp", "vApp", vapp.VApp.Name)
+		if len(vapp.VApp.Children.VM) == 0 {
+			g.log.Debug("vapp has no VMs", "vApp", vapp.VApp.HREF)
+			continue
+		}
+
+		g.log.Debug("refreshing vapp", "vApp", vapp.VApp.Name)
+		err := vapp.Refresh()
+		if err != nil {
+			g.log.Error("error refreshing vapp", "vApp", vapp.VApp.Name, "error", err)
+			continue
+		}
+
+		g.log.Debug("refreshing VM", "vApp", vapp.VApp.HREF)
+		vmHREF := vapp.VApp.Children.VM[0].HREF
+		vm := govcd.NewVM(&client.Client)
+		vm.VM.HREF = vmHREF
+		err = vm.Refresh()
+		if err != nil {
+			g.log.Error("error refreshing VM", "VM", vm.VM.Name, "error", err)
+			continue
+		}
+
+		size++
+
 		var state provider.State
-		switch types.VAppStatuses[vm.Status] {
+		switch types.VAppStatuses[vm.VM.Status] {
 		// The lifecycle in VCD is:
 		// - Deploying UNRESOLVED -> POWERED_OFF -> PARTIALLY_POWERED_OFF -> POWERED_ON
 		// - Deleting POWERED_ON -> PARTIALLY_POWERED_OFF -> POWERED_OFF -> DELETING -> UNKNOWN
-		case "UNRESOLVED":
+		case "UNRESOLVED", "PARTIALLY_POWERED_OFF":
 			state = provider.StateCreating
 		case "POWERED_ON":
 			state = provider.StateRunning
 		case "UNKNOWN":
 			state = provider.StateDeleting
-		case "POWERED_OFF", "PARTIALLY_POWERED_OFF":
-			// as these two states are not final, we just ignore them
-			g.log.Debug("unhandled instance status", "id", vm.HREF, "name", vm.Name, "status", vm.Status)
-		default:
-			g.log.Error("unexpected instance status", "id", vm.HREF, "name", vm.Name, "status", vm.Status)
 
+		default:
+			g.log.Info("unexpected instance status", "id", vm.VM.HREF, "name", vm.VM.Name, "status", vm.VM.Status, "statusName", types.VAppStatuses[vm.VM.Status])
+			if vm.VM.Tasks != nil {
+				for _, t := range vm.VM.Tasks.Task {
+					g.log.Debug("task", "id", t.ID, "status", t.Status, "name", t.Name, "operation", t.Operation, "vm", vm.VM.Name, "vApp", vapp.VApp.Name)
+				}
+			}
+
+			// TODO(juanfont): Check for failed signs and handle then. E.g., there is a task in the VM task list that shows failed
 		}
 
-		update(vm.HREF, state)
+		// we update the state of the VM, but we use the vApp href as id
+		// so it is easier to find the vApp in the API response
+		update(vapp.VApp.HREF, state)
 	}
 
+	g.size = size
 	return nil
 }
 
@@ -156,7 +186,7 @@ func (g *InstanceGroup) ConnectInfo(ctx context.Context, id string) (provider.Co
 		ConnectorConfig: g.settings.ConnectorConfig,
 	}
 
-	vm, err := g.getVM(id)
+	vm, err := g.getVMFromVAppHREF(id)
 	if err != nil {
 		return info, err
 	}
@@ -192,6 +222,22 @@ func (g *InstanceGroup) ConnectInfo(ctx context.Context, id string) (provider.Co
 }
 
 func (g *InstanceGroup) Shutdown(ctx context.Context) error {
-	g.log.Info("Shutting down. Deleting vApp", "vApp", g.vAppHREF)
-	return g.deleteVApp(g.vAppHREF)
+	vapps, err := g.getVappsInInstanceGroup()
+	if err != nil {
+		return fmt.Errorf("getting vapps in instance group: %w", err)
+	}
+
+	for _, vapp := range vapps {
+		if !strings.HasPrefix(vapp.VApp.Name, g.VAppNamePrefix) {
+			g.log.Warn("skipping vApp deletion", "vApp", vapp.VApp.HREF, "name", vapp.VApp.Name)
+			continue
+		}
+		g.log.Info("Shutting down. Deleting vApp", "vApp", vapp.VApp.HREF)
+		err = g.deleteVApp(vapp.VApp.HREF)
+		if err != nil {
+			g.log.Error("error deleting vApp", "vApp", vapp.VApp.HREF, "error", err)
+		}
+	}
+
+	return nil
 }

--- a/provider_integration_test.go
+++ b/provider_integration_test.go
@@ -1,15 +1,22 @@
 package vcd
 
 import (
-	"net/url"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	"gitlab.com/gitlab-org/fleeting/fleeting/integration"
 	"gitlab.com/gitlab-org/fleeting/fleeting/provider"
 )
+
+func mustAtoi(s string) int {
+	i, err := strconv.Atoi(s)
+	if err != nil {
+		panic(err)
+	}
+	return i
+}
 
 func TestProvisioning(t *testing.T) {
 	if os.Getenv("VCD_URL") == "" {
@@ -48,10 +55,6 @@ func TestProvisioning(t *testing.T) {
 		t.Error("mandatory environment variable VCD_VAPP not set")
 	}
 
-	if os.Getenv("VCD_VM_NAME_PREFIX") == "" {
-		t.Error("mandatory environment variable VCD_VM_NAME_PREFIX not set")
-	}
-
 	pluginBinary := integration.BuildPluginBinary(t, "cmd/fleeting-plugin-vcd", "fleeting-plugin-vcd")
 
 	// t.Run("static credentials via ssh keys", func(t *testing.T) {
@@ -65,12 +68,6 @@ func TestProvisioning(t *testing.T) {
 
 	// 	privateKeyPem := pem.EncodeToMemory(pemBlock)
 
-	// 	parsedURL, err := url.Parse(os.Getenv("VCD_URL"))
-	// 	require.NoError(t, err)
-
-	// 	vAppName, err := generateVMName(os.Getenv("VCD_VAPP_NAME_PREFIX"))
-	// 	require.NoError(t, err)
-
 	// 	integration.TestProvisioning(t,
 	// 		pluginBinary,
 	// 		integration.Config{
@@ -82,13 +79,15 @@ func TestProvisioning(t *testing.T) {
 	// 				Network:           os.Getenv("VCD_NETWORK"),
 	// 				IPAllocationMode:  os.Getenv("VCD_NETWORK_ALLOCATION_MODE"),
 	// 				Token:             os.Getenv("VCD_TOKEN"),
+	// 				InstanceGroupName:  "fleeting-test-pub-key",
+	// 				VAppNamePrefix:    os.Getenv("VCD_VAPP_NAME_PREFIX"),
 	// 				Catalog:           os.Getenv("VCD_CATALOG"),
 	// 				Template:          os.Getenv("VCD_TEMPLATE"),
-	// 				CPUCount:          4,
-	// 				MemoryMB:          8192,
-	// 				VApp:              vAppName,
-	// 				VMNamePrefix:      os.Getenv("VCD_VM_NAME_PREFIX"),
-	// 				parsedURL:         parsedURL,
+	// 				StorageProfile:    os.Getenv("VCD_STORAGE_PROFILE"),
+	// 				CPUCount:          mustAtoi(os.Getenv("VCD_CPU_COUNT")),
+	// 				CoresPerSocket:    mustAtoi(os.Getenv("VCD_CORES_PER_SOCKET")),
+	// 				MemoryMB:          int64(mustAtoi(os.Getenv("VCD_MEMORY_MB"))),
+	// 				DiskSizeGB:        mustAtoi(os.Getenv("VCD_DISK_SIZE_GB")),
 	// 			},
 	// 			// We need write something the Username field here. In reality, the username will be provided by ConnectInfo(),
 	// 			// and as we use VCD+VMware Tools it is always either root or Administrator.
@@ -106,12 +105,6 @@ func TestProvisioning(t *testing.T) {
 
 	t.Run("static credentials via user/password", func(t *testing.T) {
 		t.Parallel()
-		parsedURL, err := url.Parse(os.Getenv("VCD_URL"))
-		require.NoError(t, err)
-
-		vAppName, err := generateVMName(os.Getenv("VCD_VAPP_NAME_PREFIX"))
-		require.NoError(t, err)
-
 		integration.TestProvisioning(t,
 			pluginBinary,
 			integration.Config{
@@ -123,14 +116,15 @@ func TestProvisioning(t *testing.T) {
 					Network:           os.Getenv("VCD_NETWORK"),
 					IPAllocationMode:  os.Getenv("VCD_NETWORK_ALLOCATION_MODE"),
 					Token:             os.Getenv("VCD_TOKEN"),
+					InstanceGroupName: "fleeting-test-user-password",
+					VAppNamePrefix:    os.Getenv("VCD_VAPP_NAME_PREFIX"),
 					Catalog:           os.Getenv("VCD_CATALOG"),
 					Template:          os.Getenv("VCD_TEMPLATE"),
-					CPUCount:          4,
-					MemoryMB:          8192,
-					VApp:              vAppName,
-					VMNamePrefix:      os.Getenv("VCD_VM_NAME_PREFIX"),
-					parsedURL:         parsedURL,
 					StorageProfile:    os.Getenv("VCD_STORAGE_PROFILE"),
+					CPUCount:          mustAtoi(os.Getenv("VCD_CPU_COUNT")),
+					CoresPerSocket:    mustAtoi(os.Getenv("VCD_CORES_PER_SOCKET")),
+					MemoryMB:          int64(mustAtoi(os.Getenv("VCD_MEMORY_MB"))),
+					DiskSizeGB:        mustAtoi(os.Getenv("VCD_DISK_SIZE_GB")),
 				},
 				// We need write some thing the Username field here. In reality, the username will be provided by ConnectInfo(),
 				// and as we use VCD+VMware Tools it is always either root or Administrator.

--- a/scripts.go
+++ b/scripts.go
@@ -13,7 +13,28 @@ elif [ x$1 == x"postcustomization" ]; then
 fi`
 
 	windowsGuestCustomizationScript = `@echo off
-if "%1" == "postcustomization" (
-	echo {{.PublicKey}} > C:\ProgramData\ssh\administrators_authorized_keys
-)`
+if "%1" == "precustomization" (
+	echo Performing precustomization tasks
+) else if "%1" == "postcustomization" (
+	echo Performing postcustomization tasks
+	
+	REM Create the .ssh directory if it doesn't exist
+	if not exist C:\Users\administrator\.ssh mkdir C:\Users\administrator\.ssh
+
+	REM Add SSH public key
+	echo {{.PublicKey}} > C:\Users\administrator\.ssh\authorized_keys
+	
+	REM Set appropriate permissions on the authorized_keys file
+	icacls C:\Users\administrator\.ssh\authorized_keys /inheritance:r /grant "Administrators:F" /grant "SYSTEM:F"	
+	
+	REM Restart the SSH service
+	net stop sshd
+	net start sshd
+	
+	REM Ensure the SSH service starts automatically
+	sc config sshd start= auto
+	
+	echo Postcustomization tasks completed
+)
+`
 )

--- a/vcd.go
+++ b/vcd.go
@@ -3,6 +3,7 @@ package vcd
 import (
 	"bytes"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -15,52 +16,13 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-func (g *InstanceGroup) getOrCreateVApp() (*govcd.VApp, error) {
-	vapp, err := g.getVApp()
-	if err != nil {
-		vapp, err = g.createVApp()
-		if err != nil {
-			return nil, err
-		}
-	}
-	return vapp, nil
-}
+var (
+	errTemplateNotReady      = errors.New("template not ready (status != 8)")
+	errUnexpectedNumberOfVMs = errors.New("unexpected number of VMs in template")
+	errDiskSectionNotFound   = errors.New("disk section not found")
+)
 
-func (g *InstanceGroup) getVApp() (*govcd.VApp, error) {
-	client, err := newClient(*g.parsedURL, g.Org, g.Token, false)
-	if err != nil {
-		return nil, err
-	}
-
-	if g.vAppHREF != "" { // this is way quicker
-		vapp := govcd.NewVApp(&client.Client)
-		vapp.VApp.HREF = g.vAppHREF
-		err = vapp.Refresh()
-		if err != nil {
-			return nil, err
-		}
-		return vapp, nil
-	}
-
-	org, err := client.GetOrgByName(g.Org)
-	if err != nil {
-		return nil, err
-	}
-
-	vdc, err := org.GetVDCByName(g.VirtualDatacenter, false)
-	if err != nil {
-		return nil, err
-	}
-
-	vapp, err := vdc.GetVAppByName(g.VApp, true)
-	if err != nil {
-		return nil, err
-	}
-
-	return vapp, nil
-}
-
-func (g *InstanceGroup) createVApp() (*govcd.VApp, error) {
+func (g *InstanceGroup) createVM() (*govcd.VM, error) {
 	client, err := newClient(*g.parsedURL, g.Org, g.Token, false)
 	if err != nil {
 		return nil, err
@@ -71,12 +33,13 @@ func (g *InstanceGroup) createVApp() (*govcd.VApp, error) {
 		return nil, err
 	}
 
-	vdc, err := org.GetVDCByName(g.VirtualDatacenter, false)
+	vdc, err := org.GetVDCByName(g.VirtualDatacenter, true)
 	if err != nil {
+		g.log.Error("vdc %s not found", g.VirtualDatacenter)
 		return nil, err
 	}
 
-	vapp, err := vdc.CreateRawVApp(g.VApp, "vApp createed for GitLab fleeting")
+	template, err := g.getVAppTemplate()
 	if err != nil {
 		return nil, err
 	}
@@ -86,80 +49,168 @@ func (g *InstanceGroup) createVApp() (*govcd.VApp, error) {
 		return nil, err
 	}
 
-	_, err = vapp.AddOrgNetwork(&govcd.VappNetworkSettings{}, network.OrgVDCNetwork, false)
+	storageProfile, err := g.getStorageProfile()
+	if err != nil {
+		g.log.Error("error getting storage profile", "error", err)
+		return nil, err
+	}
+
+	vAppName, err := generateVMName(g.VAppNamePrefix)
 	if err != nil {
 		return nil, err
 	}
 
-	return vapp, nil
-}
+	g.log.Info("Creating a new vApp", "vapp", vAppName, "template", template.VAppTemplate.Name)
+	networks := []*types.OrgVDCNetwork{}
+	networks = append(networks, network.OrgVDCNetwork)
+	task, err := vdc.ComposeVApp(
+		networks,
+		*template,
+		*storageProfile,
+		vAppName,
+		fmt.Sprintf("VM created by the %s GitLab Fleeting runner", g.Name),
+		true)
+	if err != nil {
+		g.log.Error("error creating vapp", "error", err)
+		return nil, err
+	}
 
-func (g *InstanceGroup) getStorageProfile(storageProfileName string) (*types.Reference, error) {
-	client, err := newClient(*g.parsedURL, g.Org, g.Token, false)
+	if err = task.WaitTaskCompletion(); err != nil {
+		g.log.Error("error waiting for task completion", "error", err)
+		return nil, err
+	}
+
+	vapp, err := vdc.GetVAppByName(vAppName, true)
+	if err != nil {
+		g.log.Error("error getting vapp", "error", err)
+		return nil, err
+	}
+
+	if len(vapp.VApp.Children.VM) != 1 {
+		g.log.Error("expected 1 VM, got %d", len(vapp.VApp.Children.VM))
+		return nil, errUnexpectedNumberOfVMs
+	}
+
+	g.log.Debug("waiting for VM to be fully created", "vm", vapp.VApp.Children.VM[0].Name)
+
+	vm, err := waitForVMCreation(client, vapp)
 	if err != nil {
 		return nil, err
 	}
 
-	org, err := client.GetOrgByName(g.Org)
+	g.log.Debug("VM is ready", "vm", vm.VM.Name)
+
+	err = vapp.AddMetadataEntry(types.MetadataStringValue, instanceGroupMetadataKey, g.InstanceGroupName)
 	if err != nil {
 		return nil, err
 	}
 
-	vdc, err := org.GetVDCByName(g.VirtualDatacenter, false)
+	g.log.Debug("injecting credentials", "vm", vm.VM.Name)
+
+	err = g.injectCredentials(vm)
 	if err != nil {
 		return nil, err
 	}
 
-	storageProfile, err := vdc.FindStorageProfileReference(storageProfileName)
-	if err != nil {
-		return nil, err
-	}
+	g.log.Debug("refreshing VM", "vm", vm.VM.Name)
 
-	return &storageProfile, nil
-}
-
-func (g *InstanceGroup) getVM(href string) (*govcd.VM, error) {
-	client, err := newClient(*g.parsedURL, g.Org, g.Token, false)
-	if err != nil {
-		return nil, err
-	}
-
-	vm := govcd.NewVM(&client.Client)
-	vm.VM.HREF = href
 	err = vm.Refresh()
 	if err != nil {
 		return nil, err
 	}
 
-	return vm, nil
+	// vm, err = g.renameVM(client, vm, vAppName)
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	err = vm.ChangeCPUAndCoreCount(&g.CPUCount, &g.CoresPerSocket)
+	if err != nil {
+		return nil, err
+	}
+
+	err = vm.ChangeMemory(g.MemoryMB)
+	if err != nil {
+		return nil, err
+	}
+
+	vm, err = g.changeDiskSize(vm)
+	if err != nil {
+		return nil, err
+	}
+
+	g.log.Debug("powering on vm", "vm", vm.VM.Name)
+
+	task, err = vm.PowerOn()
+	if err != nil {
+		return nil, err
+	}
+	if err = task.WaitTaskCompletion(); err != nil {
+		return nil, err
+	}
+
+	g.log.Debug("VM reported as powered on", "vm", vm.VM.Name)
+
+	if status, err := vm.GetStatus(); err != nil || status != "POWERED_ON" {
+		panic(fmt.Sprintf("vm %s is not powered on: %s", vm.VM.Name, err))
+	}
+
+	g.log.Debug("VM is powered on", "vm", vm.VM.Name)
+
+	return vm, err
 }
 
-func (g *InstanceGroup) deleteVM(href string) error {
+func (g *InstanceGroup) getVappsInInstanceGroup() ([]*govcd.VApp, error) {
 	client, err := newClient(*g.parsedURL, g.Org, g.Token, false)
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("error creating client: %w", err)
 	}
 
-	vm := govcd.NewVM(&client.Client)
-	vm.VM.HREF = href
-
-	task, err := vm.Undeploy() // we don't care about a hard power-off
+	org, err := client.GetOrgByName(g.Org)
 	if err != nil {
-		// it's fine if the VM is already powered off
-		g.log.Info("unable to undeploy VM, probably because it is already off", "error", err, "vm", vm.VM.Name)
-	} else {
-		err = task.WaitTaskCompletion()
+		return nil, fmt.Errorf("error getting org: %w", err)
+	}
+
+	vdc, err := org.GetVDCByName(g.VirtualDatacenter, true)
+	if err != nil {
+		return nil, fmt.Errorf("error getting VDC: %w", err)
+	}
+
+	criteria := &govcd.FilterDef{
+		Filters: map[string]string{
+			"name_regex": fmt.Sprintf("^%s", g.VAppNamePrefix),
+		},
+		Metadata: []govcd.MetadataDef{
+			{
+				Key:      instanceGroupMetadataKey,
+				Type:     "STRING",
+				Value:    g.InstanceGroupName,
+				IsSystem: false,
+			},
+		},
+		UseMetadataApiFilter: true,
+	}
+
+	results, _, err := client.Client.SearchByFilter(types.QtVapp, criteria)
+	if err != nil {
+		g.log.Error("error searching for vapps", "error", err)
+		return nil, err
+	}
+
+	vApps := []*govcd.VApp{}
+	for _, result := range results {
+		vApp, err := vdc.GetVAppByHref(result.GetHref())
 		if err != nil {
-			return err
+			g.log.Warn("error getting vApp",
+				"name", result.GetName(),
+				"href", result.GetHref(), "error", err)
+			continue
 		}
+
+		vApps = append(vApps, vApp)
 	}
 
-	err = vm.Delete()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return vApps, nil
 }
 
 func (g *InstanceGroup) deleteVApp(href string) error {
@@ -170,8 +221,29 @@ func (g *InstanceGroup) deleteVApp(href string) error {
 
 	vapp := govcd.NewVApp(&client.Client)
 	vapp.VApp.HREF = href
+	err = vapp.Refresh()
+	if err != nil {
+		return err
+	}
 
-	task, err := vapp.Undeploy()
+	g.log.Debug("powering off vapp", "vapp", vapp.VApp.Name, "statusStr", types.VAppStatuses[vapp.VApp.Status], "statusInt", vapp.VApp.Status)
+
+	task, err := vapp.PowerOff()
+	if err != nil {
+		g.log.Info("unable to power off as it's already powered off", "error", err, "vapp", vapp.VApp.Name)
+	} else {
+		err = task.WaitTaskCompletion()
+		if err != nil {
+			return err
+		}
+	}
+
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return err
+	}
+
+	task, err = vapp.Undeploy()
 	if err != nil {
 		// it's fine if the VApp is already powered off
 		g.log.Info("unable to undeploy VApp, probably because it is already off", "error", err, "vapp", vapp.VApp.Name)
@@ -190,106 +262,144 @@ func (g *InstanceGroup) deleteVApp(href string) error {
 	return task.WaitTaskCompletion()
 }
 
-func (g *InstanceGroup) addVMToVApp() (*govcd.VM, error) {
-	vapp, err := g.getVApp()
-	if err != nil {
-		return nil, err
-	}
-
-	vmName, err := generateVMName(g.VMNamePrefix)
-	if err != nil {
-		return nil, err
-	}
-
-	template, err := g.getVAppTemplate()
-	if err != nil {
-		return nil, err
-	}
-
-	netSection, err := g.getVMNetworkConnectionSection()
-	if err != nil {
-		return nil, err
-	}
-
-	var storageProfile *types.Reference = nil
-	if g.StorageProfile != "" {
-		storageProfile, err = g.getStorageProfile(g.StorageProfile)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// TODO(juanfont): fully use vapp.AddNewVMWithComputePolicy with storage and compute policies
-	task, err := vapp.AddNewVMWithComputePolicy(
-		vmName,
-		template,
-		netSection,     // network
-		storageProfile, // storage
-		nil,            // compute policy
-		true,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = task.WaitTaskCompletion(); err != nil {
-		return nil, err
-	}
-
-	vm, err := vapp.GetVMByName(vmName, true)
-	if err != nil {
-		return nil, err
-	}
-
-	err = g.injectCredentials(vm)
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO(juanfont): Change this to also get the number of cores per socket
-	err = vm.ChangeCPUAndCoreCount(&g.CPUCount, &g.CPUCount)
-	if err != nil {
-		return nil, err
-	}
-
-	err = vm.ChangeMemory(g.MemoryMB)
-	if err != nil {
-		return nil, err
-	}
-
-	task, err = vapp.PowerOn()
-	if err != nil {
-		return nil, err
-	}
-	if err = task.WaitTaskCompletion(); err != nil {
-		return nil, err
-	}
-
-	return vm, err
-}
-
-func (g *InstanceGroup) getVAppTemplate() (govcd.VAppTemplate, error) {
+func (g *InstanceGroup) getStorageProfile() (*types.Reference, error) {
 	client, err := newClient(*g.parsedURL, g.Org, g.Token, false)
 	if err != nil {
-		return govcd.VAppTemplate{}, err
+		return nil, err
 	}
 
 	org, err := client.GetOrgByName(g.Org)
 	if err != nil {
-		return govcd.VAppTemplate{}, err
+		return nil, err
+	}
+
+	vdc, err := org.GetVDCByName(g.VirtualDatacenter, false)
+	if err != nil {
+		return nil, err
+	}
+
+	storageProfile, err := vdc.FindStorageProfileReference(g.StorageProfile)
+	if err != nil {
+		return nil, err
+	}
+
+	return &storageProfile, nil
+}
+
+func (g *InstanceGroup) renameVM(client *govcd.VCDClient, vm *govcd.VM, name string) (*govcd.VM, error) {
+	vm.VM.GuestCustomizationSection.ComputerName = name
+	_, err := vm.SetGuestCustomizationSection(vm.VM.GuestCustomizationSection)
+	if err != nil {
+		return nil, err
+	}
+
+	apiEndpoint, _ := url.ParseRequestURI(vm.VM.HREF + "/action/reconfigureVm")
+	task, err := client.Client.ExecuteTaskRequest(apiEndpoint.String(), http.MethodPost,
+		types.MimeVM, "error modifying VM: %s", &types.Vm{
+			Xmlns: types.XMLNamespaceVCloud,
+			Ovf:   types.XMLNamespaceOVF,
+			Name:  name,
+		})
+	if err != nil {
+		return nil, err
+	}
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return nil, err
+	}
+
+	err = vm.Refresh()
+	if err != nil {
+		return nil, err
+	}
+
+	return vm, nil
+}
+
+func (g *InstanceGroup) changeDiskSize(vm *govcd.VM) (*govcd.VM, error) {
+	if vm.VM.VmSpecSection.DiskSection == nil || len(vm.VM.VmSpecSection.DiskSection.DiskSettings) == 0 {
+		g.log.Error("disk section not found")
+		return nil, errDiskSectionNotFound
+	}
+
+	if vm.VM.VmSpecSection.DiskSection.DiskSettings[0].SizeMb >= int64(g.DiskSizeGB)*1024 {
+		g.log.Info("current disk size is >= of the desired size. doing nothing.", "size", vm.VM.VmSpecSection.DiskSection.DiskSettings[0].SizeMb)
+		return vm, nil
+	}
+
+	g.log.Debug("changing disk size to", "size", g.DiskSizeGB)
+	vm.VM.VmSpecSection.DiskSection.DiskSettings[0].SizeMb = int64(g.DiskSizeGB) * 1024
+	vm, err := vm.UpdateVmSpecSection(vm.VM.VmSpecSection, "")
+	if err != nil {
+		return nil, err
+	}
+
+	err = vm.Refresh()
+	if err != nil {
+		return nil, err
+	}
+
+	return vm, nil
+}
+
+func (g *InstanceGroup) getVMFromVAppHREF(vAppHREF string) (*govcd.VM, error) {
+	client, err := newClient(*g.parsedURL, g.Org, g.Token, false)
+	if err != nil {
+		return nil, err
+	}
+
+	vapp := govcd.NewVApp(&client.Client)
+	vapp.VApp.HREF = vAppHREF
+	err = vapp.Refresh()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(vapp.VApp.Children.VM) != 1 {
+		return nil, errUnexpectedNumberOfVMs
+	}
+
+	vm := govcd.NewVM(&client.Client)
+	vm.VM.HREF = vapp.VApp.Children.VM[0].HREF
+	err = vm.Refresh()
+	if err != nil {
+		return nil, err
+	}
+
+	return vm, nil
+}
+
+func (g *InstanceGroup) getVAppTemplate() (*govcd.VAppTemplate, error) {
+	client, err := newClient(*g.parsedURL, g.Org, g.Token, false)
+	if err != nil {
+		return nil, err
+	}
+
+	org, err := client.GetOrgByName(g.Org)
+	if err != nil {
+		return nil, err
 	}
 
 	catalog, err := org.GetCatalogByName(g.Catalog, true)
 	if err != nil {
-		return govcd.VAppTemplate{}, err
+		return nil, err
 	}
 
 	catalogItem, err := catalog.GetCatalogItemByName(g.Template, true)
 	if err != nil {
-		return govcd.VAppTemplate{}, err
+		return nil, err
 	}
 
-	return catalogItem.GetVAppTemplate()
+	template, err := catalogItem.GetVAppTemplate()
+	if err != nil {
+		return nil, err
+	}
+
+	if template.VAppTemplate.Status != 8 {
+		return nil, errTemplateNotReady
+	}
+
+	return &template, nil
 }
 
 func (g *InstanceGroup) getVMNetworkConnectionSection() (*types.NetworkConnectionSection, error) {
@@ -365,6 +475,62 @@ func (g *InstanceGroup) injectCredentials(vm *govcd.VM) error {
 	}
 	_, err := vm.SetGuestCustomizationSection(vm.VM.GuestCustomizationSection)
 	return err
+}
+
+func waitForVMCreation(client *govcd.VCDClient, vapp *govcd.VApp) (*govcd.VM, error) {
+	vm := govcd.NewVM(&client.Client)
+	vm.VM.HREF = vapp.VApp.Children.VM[0].HREF
+	err := vm.Refresh()
+	if err != nil {
+		return nil, err
+	}
+
+	cWait := make(chan string, 1)
+	go func() {
+		for {
+			status, _ := vm.GetStatus()
+			if status == "POWERED_OFF" {
+				break
+			}
+			time.Sleep(5 * time.Second)
+		}
+
+		for {
+			vapp.Refresh()
+			if err != nil {
+				cWait <- "err"
+				return
+			}
+			if vapp.VApp.Tasks == nil {
+				time.Sleep(15 * time.Second) // let's give this old chap some time
+				break
+
+			}
+			time.Sleep(5 * time.Second)
+		}
+
+		cWait <- "ok"
+	}()
+
+	select {
+	case res := <-cWait:
+		if res == "err" {
+			return nil, fmt.Errorf("error while deploying VM")
+		}
+	case <-time.After(60 * time.Minute):
+		return nil, fmt.Errorf("timeout while deploying VM")
+	}
+
+	if vm.VM.VmSpecSection == nil {
+		return nil, fmt.Errorf("VM spec section not found")
+	}
+
+	err = vm.Refresh()
+	if err != nil {
+		return nil, err
+	}
+
+	return vm, nil
 }
 
 func newClient(apiURL url.URL, org string, token string, insecure bool) (*govcd.VCDClient, error) {


### PR DESCRIPTION
VCD does not have the concept of instance groups. This means that we need to manage the VMs/VApps individually.

Given that VCD does not support multiple operations in a VApp at the same time, we are forced to look for something else to have some kind of parallel deployment of instances.

This PR changes the way we deploy new instances, by emulating a instance group with VCD metadata tags.